### PR TITLE
Update Version 1.1

### DIFF
--- a/DecibelMeter/MainWindow.xaml
+++ b/DecibelMeter/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Decibel Meter"
         Icon="logo.ico"
-        Height="430"
+        Height="440"
         Width="460"
         Background="#222"
         Foreground="#EEE"
@@ -132,35 +132,75 @@
                    Margin="0,16,0,8"
                    HorizontalAlignment="Left"/>
 
-        <!-- Visualization bar -->
-        <Border Grid.Row="6"
-                Height="38"
-                CornerRadius="6"
-                Background="{StaticResource BarBackgroundBrush}"
-                Padding="3"
-                BorderBrush="#555"
-                BorderThickness="1">
-            <Grid>
-                <Rectangle x:Name="BarBackground"
-                           RadiusX="4"
-                           RadiusY="4"
-                           Fill="Transparent"/>
-                <Rectangle x:Name="BarLevel"
-                           Fill="{StaticResource BarFillBrush}"
-                           RadiusX="4"
-                           RadiusY="4"
-                           Width="0"
-                           HorizontalAlignment="Left"/>
-                <Line x:Name="ThresholdLine"
-                      Stroke="Orange"
-                      StrokeThickness="3"
-                      Y1="0"
-                      Y2="38"
-                      X1="0"
-                      X2="0"
-                      SnapsToDevicePixels="True"/>
+        <!-- Visualization bar with labels above -->
+        <Grid Grid.Row="6">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/> <!-- Labels row -->
+                <RowDefinition Height="Auto"/> <!-- Bar row -->
+            </Grid.RowDefinitions>
+
+            <!-- Labels above the bar -->
+            <Grid Grid.Row="0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <!-- 0% label -->
+                <TextBlock Text="0%" Foreground="#AAA" FontSize="12" FontWeight="Bold"
+                           VerticalAlignment="Bottom" HorizontalAlignment="Left" Margin="0,0,0,2"/>
+                <!-- 100% label -->
+                <TextBlock Text="100%" Foreground="#AAA" FontSize="12" FontWeight="Bold"
+                           Grid.Column="2" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="0,0,0,2"/>
+                <!-- Threshold label (positioned absolutely in code-behind) -->
+                <TextBlock x:Name="ThresholdValueLabel"
+                           Text="50%"
+                           Foreground="Orange"
+                           Background="#222"
+                           FontSize="12"
+                           FontWeight="Bold"
+                           VerticalAlignment="Bottom"
+                           Margin="0,0,0,2"
+                           RenderTransformOrigin="0.5,1"
+                           Visibility="Collapsed">
+                    <TextBlock.RenderTransform>
+                        <TranslateTransform x:Name="ThresholdValueLabelTransform"/>
+                    </TextBlock.RenderTransform>
+                </TextBlock>
             </Grid>
-        </Border>
+
+            <!-- The bar itself -->
+            <Border Grid.Row="1"
+                    Height="38"
+                    CornerRadius="6"
+                    Background="{StaticResource BarBackgroundBrush}"
+                    Padding="3"
+                    BorderBrush="#555"
+                    BorderThickness="1"
+                    VerticalAlignment="Bottom">
+                <Grid>
+                    <Rectangle x:Name="BarBackground"
+                               RadiusX="4"
+                               RadiusY="4"
+                               Fill="Transparent"/>
+                    <Rectangle x:Name="BarLevel"
+                               Fill="{StaticResource BarFillBrush}"
+                               RadiusX="4"
+                               RadiusY="4"
+                               Width="0"
+                               HorizontalAlignment="Left"/>
+                    <Line x:Name="ThresholdLine"
+                          Stroke="Orange"
+                          StrokeThickness="3"
+                          Y1="0"
+                          Y2="38"
+                          X1="0"
+                          X2="0"
+                          SnapsToDevicePixels="True"
+                          Visibility="Collapsed"/>
+                </Grid>
+            </Border>
+        </Grid>
 
         <!-- Buttons -->
         <StackPanel Grid.Row="7"

--- a/DecibelMeter/MainWindow.xaml
+++ b/DecibelMeter/MainWindow.xaml
@@ -77,7 +77,7 @@
                 <TextBox x:Name="ThresholdBox"
                          Width="140"
                          HorizontalAlignment="Left"
-                         ToolTip="Trigger warning when level exceeds this percentage (0-100)"/>
+                         ToolTip="Trigger warning when average level exceeds this percentage (0-100)"/>
             </StackPanel>
 
             <StackPanel Grid.Column="2" HorizontalAlignment="Left">

--- a/DecibelMeter/MainWindow.xaml
+++ b/DecibelMeter/MainWindow.xaml
@@ -1,41 +1,179 @@
 ﻿<Window x:Class="DecibelMeter.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Decibel Meter"
         Icon="logo.ico"
-        Title="Decibel Meter" Height="430" Width="400"
+        Height="430"
+        Width="460"
         Background="#222"
-        Foreground="#EEE">
-    <StackPanel Margin="10">
-        <TextBlock Text="Select Input Device:" FontWeight="Bold"/>
-        <ComboBox x:Name="DeviceComboBox" Margin="0,5"/>
+        Foreground="#EEE"
+        FontFamily="Segoe UI"
+        FontSize="13"
+        WindowStartupLocation="CenterScreen">
+    <Window.Resources>
+        <Thickness x:Key="FieldMargin">0,4,0,8</Thickness>
 
-        <TextBlock Text="Threshold (dB):" FontWeight="Bold"/>
-        <TextBox x:Name="ThresholdBox" Background="DarkGray" Margin="0,5" Text="-20"/>
+        <Style x:Key="LabelStyle" TargetType="TextBlock">
+            <Setter Property="Margin" Value="0,8,0,2"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+        </Style>
 
-        <TextBlock Text="Select Monitor:" FontWeight="Bold"/>
-        <ComboBox x:Name="MonitorComboBox" Margin="0,5"/>
+        <Style TargetType="ComboBox">
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="Background" Value="#333"/>
+        </Style>
 
-        <Button Content="Select Warning Sound" Click="SelectSound_Click" Margin="0,5"/>
-        <TextBlock x:Name="SelectedSoundText" Text="No file selected" Margin="0,2"/>
+        <Style TargetType="TextBox">
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="Background" Value="#333"/>
+            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Foreground" Value="#EEE"/>
+        </Style>
 
-        <TextBlock Text="Warning Sound Volume (0-200):" FontWeight="Bold"/>
-        <TextBox x:Name="VolumeBox" Margin="0,5" Text="100"/>
+        <Style TargetType="Button">
+            <Setter Property="Margin" Value="0,0,8,0"/>
+            <Setter Property="Padding" Value="10,4"/>
+            <Setter Property="Background" Value="#3A3A3A"/>
+            <Setter Property="BorderBrush" Value="#555"/>
+            <Setter Property="Foreground" Value="#EEE"/>
+        </Style>
 
+        <SolidColorBrush x:Key="BarBackgroundBrush" Color="#444"/>
+        <SolidColorBrush x:Key="BarFillBrush" Color="#2FAF41"/>
+        <SolidColorBrush x:Key="BarOverThresholdBrush" Color="#C84728"/>
+    </Window.Resources>
 
-        <TextBlock x:Name="OutputText" FontSize="16" FontWeight="Bold" Margin="0,5"/>
+    <Grid Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
 
-        <!-- Start / Stop -->
-        <StackPanel Orientation="Horizontal" Margin="0,15" HorizontalAlignment="Center">
-            <Button Content="Start Monitoring" Click="Start_Click" Width="120" Margin="0,0,5,0"/>
-            <Button Content="Stop Monitoring" Click="Stop_Click" Width="120"/>
+        <!-- Device -->
+        <TextBlock Grid.Row="1" Text="Input Device:" Style="{StaticResource LabelStyle}"/>
+        <ComboBox Grid.Row="1"
+                  x:Name="DeviceComboBox"
+                  HorizontalAlignment="Stretch"
+                  Margin="0,28,0,8"
+                  ToolTip="Select the capture/input device"/>
+
+        <!-- Threshold + Monitor -->
+        <Grid Grid.Row="2" Margin="0,4,0,4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="14"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+
+            <!-- Ensure left alignment -->
+            <StackPanel Grid.Column="0" HorizontalAlignment="Left">
+                <TextBlock Text="Threshold (%) :" Style="{StaticResource LabelStyle}" HorizontalAlignment="Left"/>
+                <TextBox x:Name="ThresholdBox"
+                         Width="140"
+                         HorizontalAlignment="Left"
+                         ToolTip="Trigger warning when level exceeds this percentage (0-100)"/>
+            </StackPanel>
+
+            <StackPanel Grid.Column="2" HorizontalAlignment="Left">
+                <TextBlock Text="Monitor:" Style="{StaticResource LabelStyle}" HorizontalAlignment="Left"/>
+                <ComboBox x:Name="MonitorComboBox"
+                          Width="140"
+                          HorizontalAlignment="Left"
+                          ToolTip="Screen where the overlay is shown"/>
+            </StackPanel>
+        </Grid>
+
+        <!-- Warning sound -->
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    VerticalAlignment="Center"
+                    Margin="0,8,0,0">
+            <Button Content="Select Warning Sound"
+                    Click="SelectSound_Click"
+                    Width="170"/>
+            <TextBlock x:Name="SelectedSoundText"
+                       Margin="8,4,0,0"
+                       VerticalAlignment="Center"
+                       Foreground="#BBB"
+                       Text="No file selected"
+                       ToolTip="Currently selected warning sound file"/>
         </StackPanel>
 
-
-        <!-- Visualisation -->
-        <Grid Height="50" Margin="0,0">
-            <Rectangle x:Name="BarBackground" Fill="DarkGray" RadiusX="5" RadiusY="5"/>
-            <Rectangle x:Name="BarLevel" Fill="Green" RadiusX="5" RadiusY="5" Width="0" HorizontalAlignment="Left"/>
-            <Line x:Name="ThresholdLine" Stroke="Red" StrokeThickness="3" X1="2" Y1="0" X2="0" Y2="50"/>
+        <!-- Warning sound volume (two-row grid for clean alignment) -->
+        <Grid Grid.Row="4" Margin="0,8,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="0"
+                       Text="Warning Sound Volume (0-200):"
+                       Style="{StaticResource LabelStyle}"
+                       HorizontalAlignment="Left"/>
+            <TextBox Grid.Row="1"
+                     x:Name="VolumeBox"
+                     Width="140"
+                     Text="100"
+                     HorizontalAlignment="Left"
+                     ToolTip="Playback volume multiplier for the warning sound"/>
         </Grid>
-    </StackPanel>
+
+        <!-- Level output -->
+        <TextBlock Grid.Row="5"
+                   x:Name="OutputText"
+                   FontSize="18"
+                   FontWeight="Bold"
+                   Text="Level: 0%"
+                   Margin="0,16,0,8"
+                   HorizontalAlignment="Left"/>
+
+        <!-- Visualization bar -->
+        <Border Grid.Row="6"
+                Height="38"
+                CornerRadius="6"
+                Background="{StaticResource BarBackgroundBrush}"
+                Padding="3"
+                BorderBrush="#555"
+                BorderThickness="1">
+            <Grid>
+                <Rectangle x:Name="BarBackground"
+                           RadiusX="4"
+                           RadiusY="4"
+                           Fill="Transparent"/>
+                <Rectangle x:Name="BarLevel"
+                           Fill="{StaticResource BarFillBrush}"
+                           RadiusX="4"
+                           RadiusY="4"
+                           Width="0"
+                           HorizontalAlignment="Left"/>
+                <Line x:Name="ThresholdLine"
+                      Stroke="Orange"
+                      StrokeThickness="3"
+                      Y1="0"
+                      Y2="38"
+                      X1="0"
+                      X2="0"
+                      SnapsToDevicePixels="True"/>
+            </Grid>
+        </Border>
+
+        <!-- Buttons -->
+        <StackPanel Grid.Row="7"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Center"
+                    Margin="0,16,0,0">
+            <Button Content="Start Monitoring"
+                    Width="150"
+                    Click="Start_Click"/>
+            <Button Content="Stop Monitoring"
+                    Width="150"
+                    Click="Stop_Click"
+                    Margin="8,0,0,0"/>
+        </StackPanel>
+    </Grid>
 </Window>

--- a/DecibelMeter/MainWindow.xaml.cs
+++ b/DecibelMeter/MainWindow.xaml.cs
@@ -104,6 +104,10 @@ namespace DecibelMeter
             audioService = null;
             OutputText.Text = "Monitoring stopped.";
             HideOverlay(); // Hide overlay window
+
+            // Hide the threshold line
+            ThresholdLine.Visibility = Visibility.Collapsed;
+            ThresholdValueLabel.Visibility = Visibility.Collapsed;
         }
 
         // Receives percent (0-100)
@@ -165,6 +169,17 @@ namespace DecibelMeter
                 ThresholdLine.X1 = x;
                 ThresholdLine.X2 = x;
                 ThresholdLine.Visibility = Visibility.Visible;
+                ThresholdValueLabel.Visibility = Visibility.Visible;
+
+                // Update threshold label value and position
+                ThresholdValueLabel.Text = $"{thresholdPercent:F0}%";
+                // Center the label horizontally above the threshold line
+                double labelWidth = ThresholdValueLabel.ActualWidth;
+                // If label width is not available yet, use a default estimate (e.g., 24)
+                if (labelWidth == 0) labelWidth = 24;
+                // Offset so label is centered above the line
+                double offset = x - (labelWidth / 2);
+                ThresholdValueLabel.RenderTransform = new TranslateTransform(offset, 0);
             }
         }
 

--- a/DecibelMeter/MainWindow.xaml.cs
+++ b/DecibelMeter/MainWindow.xaml.cs
@@ -204,19 +204,16 @@ namespace DecibelMeter
             overlay.Left = selectedScreen.Bounds.Left / dpiX + (selectedScreen.Bounds.Width / dpiX - overlay.Width) / 2;
             overlay.Top = selectedScreen.Bounds.Top / dpiY + (selectedScreen.Bounds.Height / dpiY - overlay.Height) / 2;
 
-            if (!overlayShown)
-            {
-                overlay.Visibility = Visibility.Visible;
-                overlayShown = true;
-            }
+            overlay.CancelPendingHide(); // Ensures overlay stays visible and cancels fade-out
+            overlayShown = true;
         }
 
-        // Hides overlay window
+        // Hides overlay window with fade out effect
         private void HideOverlay()
         {
-            if (overlay != null)
+            if (overlay != null && overlay.Visibility == Visibility.Visible)
             {
-                overlay.Visibility = Visibility.Hidden;
+                overlay.FadeOutAndHide();
                 overlayShown = false;
             }
         }

--- a/DecibelMeter/Models/Config.cs
+++ b/DecibelMeter/Models/Config.cs
@@ -1,15 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.Json.Serialization;
 
 namespace DecibelMeter.Models
 {
     public class Config
     {
         public string SelectedDevice { get; set; } = "";
-        public int ThresholdDb { get; set; } = 50;
+
+        // Stored/used as percentage (0-100). Keep old JSON field name "ThresholdDb" for migration.
+        [JsonPropertyName("ThresholdDb")]
+        public int ThresholdPercent { get; set; } = 50;
+
         public int SelectedMonitor { get; set; } = 0;
         public string LastWarningSoundPath { get; set; } = "notificationsound.wav";
         public int WarningSoundVolume { get; set; } = 100;

--- a/DecibelMeter/OverlayWindow.xaml.cs
+++ b/DecibelMeter/OverlayWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using System.Windows.Media.Animation;
 using System.Windows.Media.Imaging;
 
 namespace DecibelMeter
@@ -6,6 +7,8 @@ namespace DecibelMeter
     // OverlayWindow displays a transparent overlay image on the screen
     public partial class OverlayWindow : Window
     {
+        private bool _pendingHide = false;
+
         // Initializes new instance of OverlayWindow with specified image
         // <param name="imageFileName"> Filename of overlay image to display</param>
         // Passed by MainWindow.xaml.cs as arg upon creating new instance
@@ -48,6 +51,32 @@ namespace DecibelMeter
             {
                 MessageBox.Show($"Failed to load overlay image resource:\n{ex.Message}");
             }
+        }
+
+        // Fades out the overlay over 0.5 second, then hides it
+        public void FadeOutAndHide()
+        {
+            _pendingHide = true;
+            var fade = new DoubleAnimation(1.0, 0.0, new Duration(TimeSpan.FromSeconds(0.5)));
+            fade.Completed += (s, e) =>
+            {
+                // Only hide if not re-shown in the meantime
+                if (_pendingHide)
+                {
+                    this.Visibility = Visibility.Hidden;
+                    this.Opacity = 1.0;
+                }
+            };
+            this.BeginAnimation(Window.OpacityProperty, fade);
+        }
+
+        // Call this when showing overlay to cancel pending hide
+        public void CancelPendingHide()
+        {
+            _pendingHide = false;
+            this.BeginAnimation(Window.OpacityProperty, null); // Cancel animation
+            this.Opacity = 1.0;
+            this.Visibility = Visibility.Visible;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Settings are saved automatically and loaded on startup, including:
 
 ## Changelog
 
-### 1.1 (from dev branch)
+### Version 1.1
 
 - **Switched from decibel to percent-based level monitoring** for more intuitive and device-independent readings.
 - **Threshold is now set as a percentage** (0–100%) instead of dB.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,28 @@
 
 Originally created due to my headphones isolating too well and thus my speaking volume increasing without me noticing.
 
-(I'm aware it's somewhat sphaghetti code but this my first time creating a desktop application)
+(I'm aware it's somewhat spaghetti code but this my first time creating a desktop application)
+
+---
 
 ## Features
 
-- **Real-Time Decibel Monitoring:**  
-  Continuously measures audio input from any available recording device.
+- **Real-Time Audio Level Monitoring (Percent-based):**  
+  Continuously measures audio input from any available recording device and displays the level as a normalized percentage (0–100%).
 
-- **Customizable Threshold:**  
-  Set the decibel level at which warnings are triggered.
+- **Customizable Threshold (Percent):**  
+  Set the percentage level at which warnings are triggered. The threshold is based on a normalized percent scale, making it more intuitive and consistent across devices.
+
+- **Averaged Trigger Logic:**  
+  The warning (audio and overlay) is only triggered if the average input level over the last 2 seconds exceeds the threshold, reducing false alarms from short spikes.
+
+- **Sensitivity Adjustment:**  
+  Internal sensitivity scaling ensures typical microphones can reach 100% with loud input. (No calibration required.)
 
 - **Visual Feedback:**  
-  - Live decibel level bar with a threshold indicator.
-  - Output text color changes when threshold is exceeded.
+  - Live percentage level bar with a threshold indicator.
+  - Output text color changes when the average level exceeds the threshold.
+  - **Bar Visual Aids:** 0% and 100% labels above the bar, and a dynamic threshold value label positioned above the threshold indicator.
 
 - **Audio Warning:**  
   - Play a custom warning sound when the threshold is crossed.
@@ -24,6 +33,7 @@ Originally created due to my headphones isolating too well and thus my speaking 
 
 - **Overlay Alert:**  
   - Displays a transparent, borderless overlay image on the selected monitor when the threshold is exceeded.
+  - Overlay image fades out smoothly when the level drops below the threshold.
   - Overlay image is loaded from a WPF resource (e.g., `overlay.png`).
 
 - **Multi-Monitor Support:**  
@@ -31,6 +41,8 @@ Originally created due to my headphones isolating too well and thus my speaking 
 
 - **Persistent Settings:**  
   Remembers last used device, threshold, monitor, overlay image, and warning sound.
+
+---
 
 ## Getting Started
 
@@ -56,7 +68,7 @@ Originally created due to my headphones isolating too well and thus my speaking 
    Choose your preferred audio input (microphone) from the dropdown.
 
 2. **Set Threshold:**  
-   Enter the decibel value at which you want to trigger warnings.
+   Enter the percentage value at which you want to trigger warnings.
 
 3. **Select Monitor:**  
    Choose which monitor will display the overlay image.
@@ -69,25 +81,29 @@ Originally created due to my headphones isolating too well and thus my speaking 
 
 6. **Start Monitoring:**  
    Click "Start" to begin monitoring.  
-   - When the input exceeds threshold:
-     - The overlay image appears on the selected monitor.
+   - When the average input exceeds threshold:
+     - The overlay image appears on the selected monitor and fades out smoothly when the level drops.
      - A warning sound plays.
      - UI bar and text indicate the warning state.
 
 7. **Stop Monitoring:**  
-   Click "Stop" to end monitoring and hide the overlay.
+   Click "Stop" to end monitoring and hide the overlay and threshold indicator.
 
 ### Overlay Image
 
 - The overlay image is embedded as a WPF resource not meant to be changed by the user.
 
+---
+
 ## Configuration
 
 Settings are saved automatically and loaded on startup, including:
 - Selected audio device
-- Threshold value
+- Threshold value (percent)
 - Selected monitor
 - Last used warning sound and volume
+
+---
 
 ## Dependencies
 
@@ -95,4 +111,19 @@ Settings are saved automatically and loaded on startup, including:
 
 ---
 
-**Decibel Meter** is designed for anyone needing a simple, customizable audio level monitor with visual and audio alerts.  
+## Changelog
+
+### 1.1 (from dev branch)
+
+- **Switched from decibel to percent-based level monitoring** for more intuitive and device-independent readings.
+- **Threshold is now set as a percentage** (0–100%) instead of dB.
+- **Averaged trigger logic:** Warnings are only triggered if the average level over the last 2 seconds exceeds the threshold avoiding false positives.
+- **Sensitivity adjustment:** Internal scaling ensures typical microphones can reach 100% with loud input.
+- **Overlay fade-out:** Overlay image now fades out smoothly over 1 second instead of disappearing instantly.
+- **Bar visual aids:** Added 0% and 100% labels above the bar, and a dynamic threshold value label positioned above the threshold indicator.
+- **Threshold indicator is hidden until monitoring starts** to avoid visual clutter.
+- **Numerous UI/UX overhaul/improvements** for clarity and usability.
+
+---
+
+**Decibel Meter** is designed for anyone needing a simple, customizable audio level monitor with visual and audio alerts.


### PR DESCRIPTION
**Changelog**

### Version 1.1
- **Switched from decibel to percent-based level monitoring** for more intuitive and device-independent readings.
- **Threshold is now set as a percentage** (0–100%) instead of dB.
- **Averaged trigger logic:** Warnings are only triggered if the average level over the last 2 seconds exceeds the threshold avoiding false positives.
- **Sensitivity adjustment:** Internal scaling ensures typical microphones can reach 100% with loud input.
- **Overlay fade-out:** Overlay image now fades out smoothly over 1 second instead of disappearing instantly.
- **Bar visual aids:** Added 0% and 100% labels above the bar, and a dynamic threshold value label positioned above the threshold indicator.
- **Threshold indicator is hidden until monitoring starts** to avoid visual clutter.
- **Numerous UI/UX overhaul/improvements** for clarity and usability.